### PR TITLE
dbt-adapters 1.22.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: true  # [py<310]
+  skip: true  # [py<310 or py>313]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "dbt-adapters" %}
-{% set version = "1.21.0" %}
+{% set version = "1.22.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: 5b8da1225fdda8f2a7a5ce617e70345fdb63e0e9c3a5c5909281c1bb43f689f5
+  sha256: 0af901f9cee81342c2e113419685c0256108f0687b5ef4cb30af5f243f85af41
 
 build:
   number: 0
@@ -21,7 +21,7 @@ requirements:
     - hatchling
   run:
     - python
-    - dbt-common >=1.13,<2.0
+    - dbt-common >=1.36,<2.0
     - dbt-protos >=1.0.291,<2.0
     - pytz >=2015.7
     - agate >=1.0,<2.0


### PR DESCRIPTION
## Links
- Jira: https://anaconda.atlassian.net/browse/PKG-15855
- Dev: https://github.com/dbt-labs/dbt-adapters
- conda-forge: https://github.com/conda-forge/dbt-adapters-feedstock
- PyPI: https://pypi.org/project/dbt-adapters/1.22.0
- PyPI Inspector: https://inspector.pypi.io/project/dbt-adapters/1.22.0

## Changes
- Updated version 1.21.0 → 1.22.0
- Updated sha256
- Updated `dbt-common` lower bound `>=1.13` → `>=1.36` (per 1.22.0 pyproject.toml)
- Skip py314: `mashumaro` (run dependency) only adds Python 3.14 support from v3.17 (https://github.com/Fatal1ty/mashumaro/pull/285)

## Notes
- `dbt-common >=1.36` not yet in main (currently 1.28.0) — needs a separate PKG ticket
- Required by dbt-databricks 1.12.1 (PKG-15322)